### PR TITLE
Stream Async support and refactoring code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
     "presets": [
-        "@babel/preset-env"
+        ["@babel/preset-env", { "targets": { "node": "current" }}]
+    ],
+    "plugins": [
+        "@babel/plugin-proposal-class-properties"
     ]
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,28 @@
-let stream=require('./dist/stream.bundle').default;
+const hitTypicode = async (id) => {
+    const response = await fetch(`https://jsonplaceholder.typicode.com/todos/${id}`);
+    const json = await response.json();
+    return json;
+}
 
-Array.prototype.stream = function() {return new stream(this)};
-let arr = [1,2,3,4,5];
-let filteredArr = arr
-    .stream()
-    .filter(item => item%2)
-    .collect();
-console.log(filteredArr);
+let arr = [...Array(5).keys()];
+arr = arr.map(item => item+1);
+let mappedResponses = arr.map(async item => {
+    const json = await hitTypicode(item);
+    return json;
+});
+let reducedResponses = arr.reduce(async (agr, item) => {
+    const json = await hitTypicode(item);
+    const title = json.title;
+    const acc = await agr;
+    return acc ? `${acc} :: ${title}` : title;
+}, Promise.resolve());
+
+(async () => {
+    let mappedResp = arr.map(id => {
+        const json = await hitTypicode(id);
+        console.log(json);
+        return json;
+    });
+
+    return mappedResp;
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "streamjavascript",
+  "name": "@rakeshyeka/jstream",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -106,6 +106,20 @@
         "@babel/helper-hoist-variables": "^7.7.4",
         "@babel/traverse": "^7.7.4",
         "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz",
+      "integrity": "sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-member-expression-to-functions": "^7.7.4",
+        "@babel/helper-optimise-call-expression": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -317,6 +331,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.7.4",
         "@babel/plugin-syntax-async-generators": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz",
+      "integrity": "sha512-EcuXeV4Hv1X3+Q1TsuOmyyxeTRiSqurGJ26+I/FW1WbymmRRapVORm6x1Zl3iDIHyRxEs+VXWp6qnlcfcJSbbw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "streamjavascript",
+  "name": "@rakeshyeka/jstream",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -12,6 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.7.7",
+    "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.7",
     "babel-loader": "^8.0.6",
     "jest": "^24.9.0",
@@ -24,5 +25,6 @@
     "collectCoverageFrom": [
       "src/**.js"
     ]
-  }
+  },
+  "repository": "git://github.com/rakeshyeka/jstream.git"
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,66 @@
+export const FILTER = 'filter';
+export const MAP = 'map';
+export const chainRunnerFactory = function(proceedOnFailure, updateAccumulator) {
+    return function(ArrOrFn, accumulator) {
+        var returnItem = undefined;
+        this._arr
+            .every(newItem => {
+                var isChainDone = this._streamChain
+                    .every(action => {
+                        var [runNextAction, resp] = executeAction(action, newItem);
+                        newItem = resp;
+                        
+                        return runNextAction;
+                    })
+                const proceedNextItem = proceedOnFailure(isChainDone, newItem, ArrOrFn, accumulator);
+                [returnItem, accumulator] = updateAccumulator(isChainDone, newItem, ArrOrFn, accumulator);
+                return proceedNextItem;
+            });
+        
+        return returnItem;
+    };
+};
+
+export const asyncChainRunnerFactory = function(proceedOnFailure, updateAccumulator) {
+    return async function(ArrOrFn, accumulator) {
+        let proceedNextItem = true;
+        let returnItem = undefined;
+        for (let itemIndex=0; proceedNextItem && itemIndex<this._arr.length; itemIndex++) {
+            let newItem = this._arr[itemIndex];
+            let proceedNextAction = true, resp;
+            for (let actionIndex=0; proceedNextAction && actionIndex<this._streamChain.length; actionIndex++) {
+                let action = this._streamChain[actionIndex];
+                [proceedNextAction, resp] = await asyncExecuteAction(action, newItem);
+                newItem = resp;
+            }
+            proceedNextItem = await proceedOnFailure(proceedNextAction, newItem, ArrOrFn, accumulator);
+            [returnItem, accumulator] = await updateAccumulator(proceedNextAction, newItem, ArrOrFn, accumulator);
+        }
+
+        return returnItem;
+    };
+};
+
+export const executeAction = function(action, newItem) {
+    var runNextAction = true;
+    var resp = action.run(newItem);
+    if (action.type === FILTER && !resp) {
+        runNextAction = false;
+    } else if (action.type === MAP) {
+        newItem = resp;
+    }
+
+    return [runNextAction, newItem];
+}
+
+export const asyncExecuteAction = async function(action, newItem) {
+    var runNextAction = true;
+    var resp = await action.run(newItem);
+    if (action.type === FILTER && !resp) {
+        runNextAction = false;
+    } else if (action.type === MAP) {
+        newItem = resp;
+    }
+
+    return [runNextAction, newItem];
+}

--- a/src/streamAsync.js
+++ b/src/streamAsync.js
@@ -1,0 +1,83 @@
+import { asyncChainRunnerFactory, FILTER, MAP } from "./helper";
+
+export default class streamAsync {
+    constructor(arr) {
+        this._arr = arr;
+        this._streamChain = [];
+    }
+
+    filterAsync = (fn) => {
+        this._streamChain.push({
+            run: fn,
+            type: FILTER
+        });
+        return this;
+    }
+
+    mapAsync = (fn) => {
+        this._streamChain.push({
+            run: fn,
+            type: MAP
+        });
+        return this;
+    }
+
+    collect = asyncChainRunnerFactory(
+        async () => true,
+        async (proceedNextAction, newItem, fn, newArr) => {
+            newArr = newArr 
+                ? newArr 
+                : fn ? fn : [];
+            if (proceedNextAction) {
+                newArr.push(newItem);
+            }
+            return [newArr, newArr];
+        })
+    .bind(this);
+
+    findAsync = asyncChainRunnerFactory(
+        async (proceedNextAction, newItem, fn) => {
+            let searchNextItem = true;
+            if (proceedNextAction && await fn(newItem)) {
+                searchNextItem = false;
+            }
+
+            return searchNextItem;
+        },
+        async (proceedNextAction, newItem, fn) => {
+            return proceedNextAction && await fn(newItem) ? [newItem] : [];
+        })
+    .bind(this);
+
+    reduceAsync = asyncChainRunnerFactory(
+        async () => true,
+        async (proceedNextAction, newItem, fn, accumulator) => {
+            if (proceedNextAction) {
+                accumulator = await fn(accumulator, newItem);
+            }
+            return [accumulator, accumulator];
+        }
+    )
+    .bind(this);
+
+    async everyAsync(fn) {
+        const itemNotMatching = await this.findAsync(async item => {
+            return !(await fn(item));
+        });
+
+        return itemNotMatching === undefined;
+    }
+
+    async someAsync(fn) {
+        const itemNotMatching = await this.findAsync(async item => {
+            return !(await fn(item));
+        });
+
+        return itemNotMatching !== undefined;
+    }
+
+    async findFirst() {
+        return await this.findAsync(async () => true);
+    }
+    
+};

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -1,13 +1,14 @@
 import stream from '../src/stream';
 import {randomInt} from './testData';
 
-const arr = [...Array(randomInt(10)).keys()];
+let arr = [...Array(randomInt(6, 15)).keys()];
+arr = arr.map(item => item+1);
 
 let streamer;
 beforeEach(() => {
     streamer = new stream(arr);
 });
-console.log(stream);
+
 describe('sanity: stream', () => {
     it('should filter array', () => {
         let filterCondition = item => item%2;
@@ -92,6 +93,6 @@ describe("perf: stream", () => {
             .every(item => item%2 == 1);
         expect(every).toBeFalsy();
         expect(count).not.toEqual(arr.length);
-        expect(count).toEqual(1);
+        expect(count).toEqual(2);
     });
 });

--- a/test/streamAsync.test.js
+++ b/test/streamAsync.test.js
@@ -1,0 +1,98 @@
+import streamAsync from '../src/streamAsync';
+import {randomInt} from './testData';
+let arr = [...Array(randomInt(6, 15)).keys()];
+arr = arr.map(item => item+1);
+
+let streamer;
+beforeEach(() => {
+    streamer = new streamAsync(arr);
+});
+
+describe('sanity: streamAsync', () => {
+    it('should filter array', async () => {
+        let filterPromiseCondition = item => new Promise(resolve => resolve(item%2));
+        let filteredArr = await streamer
+            .filterAsync(filterPromiseCondition)
+            .collect();
+        expect(filteredArr).toEqual(arr.filter(item => item%2));
+    });
+    it('should map array', async () => {
+        let mapperPromise = item => new Promise(resolve => resolve(item*2));
+        let mappedArr = await streamer
+            .mapAsync(mapperPromise)
+            .collect();
+        expect(mappedArr).toEqual(arr.map(item => item*2));
+    });
+    it('should chain actions of array', async () => {
+        let filterPromiseCondition = item => new Promise(resolve => resolve(item%2));
+        let mapperPromise = item => new Promise(resolve => resolve(item*2));
+        let mappedArr = await streamer
+            .filterAsync(filterPromiseCondition)
+            .mapAsync(mapperPromise)
+            .collect([]);
+        expect(mappedArr).toEqual(arr.filter(item=>item%2).map(item => item*2));
+    });
+
+    it('should find in array', async () => {
+        let filterPromiseCondition = item => new Promise(resolve => resolve(item%5 === 0));
+        let mapperPromise = item => new Promise(resolve => resolve(item*2));
+        let first = await streamer
+            .mapAsync(mapperPromise)
+            .findAsync(filterPromiseCondition);
+        expect(first).toEqual(arr.map(item => item*2).find(item => item%5 === 0));
+    });
+
+    it('should return undefined if not found in array', async () => {
+        let filterPromiseCondition = item => new Promise(resolve => resolve(item < 0));
+        let mapperPromise = item => new Promise(resolve => resolve(item*2));
+        let first = await streamer
+            .mapAsync(mapperPromise)
+            .findAsync(filterPromiseCondition);
+        expect(first).toEqual(undefined);
+    });
+
+    it('should check every in array', async () => {
+        let mapperPromise = item => new Promise(resolve => resolve(item*2));
+        let everyPromiseCondition = item => new Promise(resolve => resolve(item%2 === 0));
+        let isEvery = await streamer
+            .mapAsync(mapperPromise)
+            .everyAsync(everyPromiseCondition);
+        expect(isEvery).toBeTruthy();
+    });
+
+    it('should return false if every not in array', async () => {
+        let mapperPromise = item => new Promise(resolve => resolve(item*2));
+        let everyPromiseCondition = item => new Promise(resolve => resolve(item%2 !== 0));
+        let isEvery = await streamer
+            .mapAsync(mapperPromise)
+            .everyAsync(everyPromiseCondition);
+        expect(isEvery).toBeFalsy();
+    });
+
+    it('should reduce array', async () => {
+        let filterCondition = item => new Promise(resolve => resolve(item%2));
+        let reducer = (agr, item) => new Promise(resolve => resolve(agr + item));
+        let init = 0;
+        let reduced = await streamer
+            .filterAsync(filterCondition)
+            .reduceAsync(reducer, init);
+        expect(reduced).toEqual(arr.filter(item => item%2).reduce((agr, item) => agr + item, init));
+    });
+
+    it('should check some in array', async () => {
+        let checkPromiseCondition = item => new Promise(resolve => resolve(item%5 === 0));
+        let isFound = await streamer
+            .someAsync(checkPromiseCondition);
+        expect(isFound).toBeTruthy();
+    });
+
+    it('should return first in an array', async () => {
+        let mapper = item => new Promise(resolve => resolve({num : item+1, isEven: (item+1)%2 == 0, isOdd: (item+1)%2 == 1}));
+        let filterCondition = item => (item+1)%5 == 0;
+        let first = await streamer
+            .filterAsync(filterCondition)
+            .mapAsync(mapper)
+            .findFirst();
+        expect(first).toEqual({num: 5, isEven: false, isOdd: true});
+    });
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,8 +12,8 @@ module.exports = (env) => {
         // Webpack will bundle all JavaScript into this file
         output: {
           path: path.resolve(__dirname, 'dist'),
-          filename: 'stream.bundle.js',
-          library: 'stream',
+          filename: 'jstream.bundle.js',
+          library: 'jstream',
           libraryTarget: 'commonjs-module'
         },
         module: {


### PR DESCRIPTION
Changes:
Moved common logic of evaluating the chained actions to helper.
Added support for processing async actions on streams. Added async counter-parts for collect, filter, map, reduce, find and other stream actions.
Added supporting unit tests for sanity of async actions.
Added babel support for handling async actions in jest unit tests.
Modified bundling library name and target.

TODO: Need to export out async actions into webpack bundling.